### PR TITLE
Confirm Password icon conflict

### DIFF
--- a/screens/SignUpScreen.js
+++ b/screens/SignUpScreen.js
@@ -162,7 +162,7 @@ const SignInScreen = ({navigation}) => {
                 <TouchableOpacity
                     onPress={updateConfirmSecureTextEntry}
                 >
-                    {data.secureTextEntry ? 
+                    {data.confirm_secureTextEntry ? 
                     <Feather 
                         name="eye-off"
                         color="grey"


### PR DESCRIPTION
Fix wrong variable `data.secureTextEntry` in the ternary operator. (refer to the video [26:03](https://youtu.be/Rs72pRwXIzA?list=PLQWFhX-gwJbmmqcP-9zMXBaxQbGKfIJY2&t=1563))